### PR TITLE
Add in-memory Irmin gitstore for Syslogd :notes:

### DIFF
--- a/config.ml
+++ b/config.ml
@@ -1,6 +1,8 @@
 open Mirage
 
 let stack = generic_stackv4 default_console tap0
+let conduit_d = conduit_direct stack
+let res_dns = resolver_dns stack
 
 let port =
   let doc = Key.Arg.info ~doc:"Listening port" ["p" ; "port" ] in
@@ -9,9 +11,9 @@ let port =
 let main =
   foreign
     ~keys:[Key.abstract port]
-    "Unikernel.Main" (console @-> stackv4 @-> clock @-> job)
+    "Unikernel.Main" (console @-> stackv4 @-> clock @-> resolver @-> conduit @-> job)
 
 let () =
-  add_to_opam_packages["syslog-message"; "irmin"];
-  add_to_ocamlfind_libraries["syslog-message"; "irmin"];
-  register "syslogd" [main $ default_console $ stack $ default_clock]
+  add_to_opam_packages["syslog-message"; "irmin"; "lwt.ppx"; "decompress"];
+  add_to_ocamlfind_libraries["syslog-message"; "irmin"; "irmin.git"; "irmin.mirage"; "irmin.mem"; "lwt.ppx"; "decompress"];
+  register "syslogd" [main $ default_console $ stack $ default_clock $res_dns $ conduit_d]

--- a/inflator.ml
+++ b/inflator.ml
@@ -1,0 +1,57 @@
+(***
+   TAKEN FROM: https://github.com/Engil/Canopy/blob/master/inflator.ml
+   Special thanks to: @yomimono, @samoht, and Canopy team.
+***)
+
+module IDBytes = struct
+    include Bytes
+    let concat = String.concat
+    let of_bytes t = t
+    let to_bytes t = t
+  end
+module XInflator = Decompress.Inflate.Make(IDBytes)
+module XDeflator = Decompress.Deflate.Make(IDBytes)
+
+let inflate ?output_size buf =
+  let output = match output_size with
+    | None -> Bytes.create (Mstruct.length buf)
+    | Some n -> Bytes.create n
+  in
+  let inflator = XInflator.make (`String (0, (Mstruct.to_string buf))) output in
+  let rec eventually_inflate inflator acc =
+    match XInflator.eval inflator with
+    | `Ok n ->
+       let res = Mstruct.of_string (IDBytes.concat "" (List.rev acc)) in
+       Mstruct.shift buf n;
+       Some res
+    | `Error -> None
+    | `Flush n ->
+       match XInflator.contents inflator with
+       | 0 ->
+          let res = Mstruct.of_string (IDBytes.concat "" (List.rev acc)) in
+          Some res
+       | _ ->
+          let tmp = Bytes.copy output in
+          XInflator.flush inflator;
+          eventually_inflate inflator (tmp :: acc)
+  in
+  eventually_inflate inflator []
+
+let deflate ?level buf =
+  let output = Bytes.create 62 in
+  let deflator = XDeflator.make ~window_bits:15
+                                (`String (0, (Cstruct.to_string buf))) output in
+  let rec eventually_deflate deflator acc =
+    match XDeflator.eval deflator with
+    | `Ok ->
+       let res = IDBytes.concat "" (List.rev acc) in
+       Cstruct.of_string res
+    | `Error -> failwith "Error deflating an archive :("
+    | `Flush ->
+       let n = Cstruct.len buf in
+       let tmp = Bytes.create n in
+       Bytes.blit_string output 0 tmp 0 n;
+       XDeflator.flush deflator;
+       eventually_deflate deflator (tmp :: acc)
+  in
+  eventually_deflate deflator []

--- a/unikernel.ml
+++ b/unikernel.ml
@@ -7,26 +7,77 @@ let green fmt  = sprintf ("\027[32m"^^fmt^^"\027[m")
 let yellow fmt = sprintf ("\027[33m"^^fmt^^"\027[m")
 let blue fmt   = sprintf ("\027[36m"^^fmt^^"\027[m")
 
-module Main (C:CONSOLE) (S:STACKV4) (Clock:V1.CLOCK) = struct
-  let timestamp_now () =
-    let now = Clock.gmtime (Clock.time ()) in
-    let open Clock in
-      (now.tm_year, (now.tm_mon + 1), now.tm_mday), ((now.tm_hour, now.tm_min, now.tm_sec), 0)
+let timestamp_now () =
+  let now = Clock.gmtime (Clock.time ()) in
+  let open Clock in
+  (now.tm_year, (now.tm_mon + 1), now.tm_mday), ((now.tm_hour, now.tm_min, now.tm_sec), 0)
 
-  let start console s c =
+module Main (C:CONSOLE) (S:STACKV4) (Clock:V1.CLOCK) (RES: Resolver_lwt.S) (CON: Conduit_mirage.S) = struct
+
+  (*
+    If you want to write to the file system, do:
+    module LoggerStore = Irmin_unix.Irmin_git.FS(Irmin.Contents.String)(Irmin.Ref.String)(Hash)
+    with:
+    let store_config = Irmin_git.config ~root:"/tmp/logger" ~bare:true ()
+    or whatever directory you want to write to.
+    This is useful for debugging :)
+
+    TODO: would be nice to have a `--debug` flag with logger that wrote to FS.
+  *)
+
+  let start console s c res con =
+    let module Context =
+      ( struct
+        let v _ = Lwt.return_some (res, con)
+      end : Irmin_mirage.CONTEXT)
+    in
+    let module Hash = Irmin.Hash.SHA1 in
+    let module Mirage_git_memory = Irmin_mirage.Irmin_git.Memory(Context)(Inflator) in
+    let module LoggerStore = Mirage_git_memory(Irmin.Contents.String)(Irmin.Ref.String)(Hash) in
+    let module LoggerSync = Irmin.Sync(LoggerStore) in
+
+    let store_config = Irmin_mem.config () in
+    let task s = Irmin.Task.create
+        ~date:(Clock.time () |> Int64.of_float)
+        ~owner:"Logger" s
+    in
+    let log_message msg =
+      LoggerStore.Repo.create store_config >>= fun r ->
+      LoggerStore.master task r >>= fun t ->
+      let pretty_msg = Syslog_message.pp_string msg in
+      (* See comment below about format *)
+      LoggerStore.update (t "Logger") ["--"] pretty_msg >>
+      (* Right now, we're just printing the read value we added. *)
+      LoggerStore.read (t "Logger") ["--"] >>= fun value ->
+      match value with
+      | Some value -> C.log_s console (blue "Git stored in Logger: %s" value)
+      | None -> C.log_s console (red "No items have been created.")
+    in
+
     let local_port = (Key_gen.port ()) in
-    S.listen_udpv4 s ~port:local_port (fun ~src ~dst ~src_port buf ->
-        match Ptime.of_date_time (timestamp_now ()) with
-        | Some ts ->
-            let ctx = {timestamp=ts;
-              Syslog_message.hostname=(Ipaddr.V4.to_string src);
-              set_hostname=false}
-            in
-            begin match Syslog_message.parse ~ctx (Cstruct.to_string buf) with
-            | None -> C.log_s console (red "Failed: %s" (Cstruct.to_string buf))
-            | Some msg -> C.log_s console (green "%s" (Syslog_message.pp_string msg))
-            end
-        | None -> C.log_s console (red "Failed / Invalid timestamp: %s" (Cstruct.to_string buf))
-    );
+    S.listen_udpv4 s ~port:local_port begin fun ~src ~dst ~src_port buf ->
+      match Ptime.of_date_time (timestamp_now ()) with
+      | Some ts ->
+        let ctx = {
+          timestamp = ts;
+          Syslog_message.hostname = (Ipaddr.V4.to_string src);
+          set_hostname = false
+        }
+        in
+        begin
+          match Syslog_message.parse ~ctx (Cstruct.to_string buf) with
+          | None -> C.log_s console (red "Failed: %s" (Cstruct.to_string buf))
+          | Some msg ->
+              (*
+                  TODO: Think about format here... should it be raw buffer,
+                        or structured JSON format? Who should be the commiter?
+                        What should the commit message be? Is there other
+                        metadata that should be associated with the commit?
+              *)
+            log_message msg >>
+            C.log_s console (green "%s" (Syslog_message.pp_string msg))
+        end
+      | None -> C.log_s console (red "Failed / Invalid timestamp: %s" (Cstruct.to_string buf))
+    end;
     S.listen s
 end


### PR DESCRIPTION
Full changes:
1. config.ml was changed to add new packages, signatures:
    - lwt.ppx (for >> syntax instead of noisy >>= fun () ->... )
    - irmin sub-packages irmin.mem, irmin.mirage, irmin.git
    - decompress lib for in-memory store
2. unikernel.ml was changed to add gitstore for each pretty-printed string of a syslog message
    - inside of a comment, I have a way to write to FS for debugging purposes if desired
3. inflator.ml file was added. It's a wrapper taken from https://github.com/Engil/Canopy/blob/master/inflator.ml

TODOs:
1. add --debug flag which writes messages to FS as opposed to in-memory
2. create structured JSON format for syslogd. Think about commit metadata, commiter, what should the "key" should be, etc.
3. There were lots of dependency issues during development of this patch. READMEs might need to be updated as people report bugs.

Special thanks to:
1. @yomomimo for tons of help :joy_cat:
2. @engil and @samoht for help with Irmin and configurations
3. @verbosemode for onboarding me to project

_This commit is also my patch for the Outreachy Mirage internship application -- deadline March 22nd._
For questions, @wiredsister on github or tweet (@wiresis).
