### PR TITLE
Fix Functor vs Struct errs in Inflator.ml to be latest with Canopy, m…

### DIFF
--- a/.merlin
+++ b/.merlin
@@ -1,6 +1,6 @@
 PKG lwt mirage mirage-types tcpip mirage-console
 PKG mirage-net-unix mirage-unix mirage-clock-unix
-PKG irmin.unix irmin
+PKG irmin decompress
 PKG syslog-message
 PKG ptime
 B **/_build/**


### PR DESCRIPTION
…erlin file tweaked.

Fixes this error: 

``` sh
> make
ocamlbuild -use-ocamlfind -pkgs conduit.mirage,decompress,dns.mirage,functoria.runtime,irmin,irmin.git,irmin.mem,irmin.mirage,lwt.ppx,mirage-clock-unix,mirage-console.unix,mirage-logs,mirage-types.lwt,mirage-unix,mirage.runtime,nocrypto.lwt,syslog-message,tcpip.stack-socket,tcpip.tcpv4-socket,tcpip.udpv4-socket -tags "warn(A-4-41-44),debug,bin_annot,strict_sequence,principal,safe_string" -tag-line "<static*.*>: warn(-32-34)" -cflag -g -lflags -g,-linkpkg main.native
+ ocamlfind ocamlc -c -g -g -bin-annot -safe-string -principal -strict-sequence -package tcpip.udpv4-socket -package tcpip.tcpv4-socket -package tcpip.stack-socket -package syslog-message -package nocrypto.lwt -package mirage.runtime -package mirage-unix -package mirage-types.lwt -package mirage-logs -package mirage-console.unix -package mirage-clock-unix -package lwt.ppx -package irmin.mirage -package irmin.mem -package irmin.git -package irmin -package functoria.runtime -package dns.mirage -package decompress -package conduit.mirage -w A-4-41-44 -o inflator.cmo inflator.ml
File "inflator.ml", line 19, characters 17-31:
Error: The module XInflator is a functor, not a structure
Command exited with code 2.
Hint: Recursive traversal of subdirectories was not enabled for this build,
  as the working directory does not look like an ocamlbuild project (no
  '_tags' or 'myocamlbuild.ml' file). If you have modules in subdirectories,
  you should add the option "-r" or create an empty '_tags' file.

  To enable recursive traversal for some subdirectories only, you can use the
  following '_tags' file:

      true: -traverse
      <dir1> or <dir2>: traverse

Compilation unsuccessful after building 6 targets (0 cached) in 00:00:00.
Makefile:26: recipe for target 'main.native' failed
make: *** [main.native] Error 10
```
